### PR TITLE
Enable ssl validation

### DIFF
--- a/YTClient/YTClient.py
+++ b/YTClient/YTClient.py
@@ -75,6 +75,21 @@ class YTClient(object):
         return self.__request(RequestType.POST, '/issues', return_fields,
                               issue_info)
 
+    def create_tag(self, name: str, visible_for: dict = None,
+                   return_fields: list = None):
+        tag_info = {'name': name}
+
+        if visible_for:
+            tag_info = {**tag_info, **visible_for}
+
+        self.headers['Cache-Control'] = 'no-cache'
+
+        if return_fields:
+            return_fields = {self.FIELDS_PARAMETER: ','.join(return_fields)}
+
+        return self.__request(RequestType.POST, '/issueTags', return_fields,
+                              tag_info)
+
     def update_issue(self, issue: Issue, summary: str, description: str = None,
                      additional_fields: dict = None,
                      return_fields: list = None):

--- a/YTClient/YTClient.py
+++ b/YTClient/YTClient.py
@@ -131,6 +131,19 @@ class YTClient(object):
 
         return self.__request(RequestType.GET, '/issues', return_fields)
 
+    def get_tags(self, fields: list = None, skip: int = None,
+                   top: int = None):
+        return_fields = {}
+
+        if fields:
+            return_fields[self.FIELDS_PARAMETER] = ','.join(fields)
+        if skip:
+            return_fields['$skip'] = skip
+        if top:
+            return_fields['$top'] = top
+
+        return self.__request(RequestType.GET, '/issueTags', return_fields)
+
     def get_projects(self, fields: list = None, skip: int = None,
                      top: int = None):
         return_fields = dict()

--- a/YTClient/YTClient.py
+++ b/YTClient/YTClient.py
@@ -38,10 +38,10 @@ class YTClient(object):
     def __init__(self, url, proxy_info=None, token=None):
         if proxy_info:
             self.http_client = httplib2.Http(
-                disable_ssl_certificate_validation=True, proxy_info=proxy_info)
+                disable_ssl_certificate_validation=False, proxy_info=proxy_info)
         else:
             self.http_client = httplib2.Http(
-                disable_ssl_certificate_validation=True)
+                disable_ssl_certificate_validation=False)
 
         self.baseUrl = url.rstrip('/')
         self.apiUrl = self.baseUrl + '/api'


### PR DESCRIPTION
Enable ssl validation in http client - targeting this branch has fixed the montagu task queue build - see this branch where there were previous failures on YT Client usage: `ValueError: Cannot set verify_mode to CERT_NONE when check_hostname is enabled.`